### PR TITLE
Small refinements for Even and UInt

### DIFF
--- a/lib/Subsets/Common.pm6
+++ b/lib/Subsets/Common.pm6
@@ -7,6 +7,7 @@ my package EXPORT::DEFAULT {
     subset PosInt of Int where * > 0;
     subset NegInt of Int where * < 0;
     subset ZeroInt of Int where * == 0;
+    # see UInt in core for Int where *>= 0
 
     subset Int8 of Int where 127 >= * >= -128;
     subset UInt8 of UInt where * <= 255;
@@ -22,7 +23,7 @@ my package EXPORT::DEFAULT {
     subset Zero of Numeric where * == 0;
     subset UNumeric of Numeric where * >= 0;
 
-    subset Even of Int where * % 2 == 0;
+    subset Even of Int where * %% 2;
     subset Odd  of Int where * % 2;
 
     subset Time::Hour12 of PosInt where * ~~ 1 .. 12;


### PR DESCRIPTION
Both minor points but hopefully of some use.  Rosetta code and the Day 8 Advent posting both use the ‘%%’ operator to implement subset Even.

https://www.rosettacode.org/wiki/Even_or_odd#Perl_6
https://perl6advent.wordpress.com/2016/12/08/how-to-make-use-and-abuse-perl-6-subsets/

The '%%' operator is implemented using '%', making it just a little slower, but the consistency may be appropriate.  The '%%' operator appears on the public facing [docs.perl6.org/language/operators](https://docs.perl6.org/language/operators#infix_%%) page.

With regard to UInt, Zoffix familiarity with UInt does not preclude the possibility it might not occur to some other programmers interested in Subsets::Common.  The subset was re-implemented on learningperl6.com Quick Tips [#17 (profiler)](https://www.learningperl6.com/2016/12/02/quick-tip-17-rakudos-built-in-profiler/) and [#18 (Short circuit subroutines)](https://www.learningperl6.com/2016/12/03/quick-tip-18-short-circuit-subroutines-with-multi/) without mention of UInt.  If the PR is accepted I may also add a note for Quick Tip #17.

